### PR TITLE
Replace soon to be deprecated seaborn distplot

### DIFF
--- a/python/AudioAnalyzer.py
+++ b/python/AudioAnalyzer.py
@@ -237,8 +237,10 @@ class SpectrumCompare():
 
         plt.figure(figsize=(8,6))
 
-        sns.distplot(samples_1)
-        sns.distplot(samples_2)
+        sns.histplot(samples_1, kde=True, stat="density", kde_kws=dict(cut=3),
+                     alpha=.4, edgecolor=(1, 1, 1, .4))
+        sns.histplot(samples_2, kde=True, stat="density", kde_kws=dict(cut=3),
+                     alpha=.4, edgecolor=(1, 1, 1, .4))
 
         plt.title(title, fontsize=18)
         plt.xlabel(xlabel, fontsize=14)


### PR DESCRIPTION
Running the code show warnings about the plans to deprecate the seaborn distplot function. This patch follows the official guide* and replaces two calls to use histplot.

* - https://gist.github.com/mwaskom/de44147ed2974457ad6372750bbe5751

Signed-off-by: Peter Senna Tschudin <peter.senna@spearline.com>